### PR TITLE
Load local properties using rootProject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+local.properties
+.gradle/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,14 @@
+import java.util.Properties
+
+val localProps = Properties().apply {
+    val propsFile = rootProject.file("local.properties")
+    if (propsFile.exists()) {
+        propsFile.inputStream().use { load(it) }
+    }
+}
+
+tasks.register("printLocalProps") {
+    doLast {
+        println("API_KEY=" + (localProps.getProperty("API_KEY") ?: "undefined"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "mysmartroute"


### PR DESCRIPTION
## Summary
- Load `local.properties` via `rootProject` in Kotlin DSL
- Add sample `printLocalProps` task and ignore sensitive files

## Testing
- `gradle -q --console=plain printLocalProps`

------
https://chatgpt.com/codex/tasks/task_e_68b20e85dba083289df4077865709aac