### PR TITLE
Προσθήκη υποστήριξης Jetpack Compose και CustomTheme

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    id("com.android.application") version "8.4.1"
+    kotlin("android") version "1.9.24"
+}
+
+android {
+    namespace = "com.ioannapergamali.mysmartroute_b"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.08.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.ioannapergamali.mysmartroute_b" />

--- a/app/src/main/java/com/ioannapergamali/mysmartroute_b/data/data/CustomTheme.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute_b/data/data/CustomTheme.kt
@@ -1,0 +1,33 @@
+package com.ioannapergamali.mysmartroute_b.data.data
+
+import androidx.compose.runtime.Composable
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+
+private val LightColors = lightColorScheme(
+    primary = Color(0xFF6200EE),
+    secondary = Color(0xFF03DAC5)
+)
+
+private val DarkColors = darkColorScheme(
+    primary = Color(0xFFBB86FC),
+    secondary = Color(0xFF03DAC5)
+)
+
+@Composable
+fun CustomTheme(
+    darkTheme: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    val colors = if (darkTheme) DarkColors else LightColors
+    MaterialTheme(
+        colorScheme = colors,
+        typography = androidx.compose.material3.Typography(
+            defaultFontFamily = FontFamily.SansSerif
+        ),
+        content = content
+    )
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,10 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "mysmartroute"
+include(":app")


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε αρθρωτό `app` με ενημερωμένο `build.gradle.kts` και βιβλιοθήκες Jetpack Compose
- Ορίστηκε `CustomTheme` με Material 3 και απλά χρώματα
- Ενημερώθηκε `settings.gradle.kts` για repositories και συμπερίληψη του `:app`

## Έλεγχοι
- `gradle tasks --stacktrace` *(αποτυχία: λείπει το plugin com.android.application)*

------
https://chatgpt.com/codex/tasks/task_e_68b228868908832881020def74743e57