### PR TITLE
Add Compose runtime dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,10 @@ dependencies {
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
+    implementation("androidx.compose.runtime:runtime")
     implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-text")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")


### PR DESCRIPTION
## Summary
- Add explicit Compose runtime, graphics, and text dependencies to enable Material3 theming.

## Testing
- `gradle build` *(fails: starting Gradle Daemon; build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b22edf2c8483288a79050a906d0bdc